### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master # Obté el codi font del repositori del GitHub
     - name: Publish to Docker Repository # El nom del repositori que es penja a Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master # La acció que fa possible la publicació del contenidor al Docker Hub
+      uses: elgohr/Publish-Docker-Github-Action@v5 # La acció que fa possible la publicació del contenidor al Docker Hub
       with:
         name: rcercosb/servei_principal # El nom del repositori en el Docker Hub
         username: ${{ secrets.DOCKER_USERNAME }} # Variable del GitHub que desa el nom d'usuàri del Docker


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore